### PR TITLE
Dev

### DIFF
--- a/src/main/java/jterm/JTerm.java
+++ b/src/main/java/jterm/JTerm.java
@@ -82,18 +82,14 @@ public class JTerm {
         command = "jterm.command." + classChar + command;
         optionsArray.remove(0);
 
-        // Get the method name
-        if (optionsArray.toArray().length >= 1) {
+        if (optionsArray.size() > 0) {
             methodName = optionsArray.get(0);
-        } else {
-            optionsArray.add(methodName);
         }
 
         try {
             Object instance = Class.forName(command)
                     .getConstructor(ArrayList.class)
                     .newInstance(optionsArray);
-            optionsArray.remove(0);
             instance.getClass()
                     .getMethod(methodName, ArrayList.class)
                     .invoke(options.getClass(), optionsArray);

--- a/src/main/java/jterm/command/Ping.java
+++ b/src/main/java/jterm/command/Ping.java
@@ -41,35 +41,36 @@ public class Ping {
     * -p port
     *	Port to ping the host on
     */
-    // FIXME: ping is failing when no options are set
     public Ping(ArrayList<String> options) {
-        String host = "google.com";
-        String port = "80";
-        boolean portNext = false;
+        if (options.size() == 0 || options.contains("-h")) {
+            System.out.println("Command syntax:\n\tping [-h] [-p port] host");
+            return;
+        }
 
-        for (String option : options) {
-            if (option.equals("-h")) {
-                System.out.println("Command syntax:\n\tping [-h] [-p port] host\n\n"
-                        + "Attempts to connect to the specified host. Default port is '80'.");
+        String port = "80";
+
+        int portIndex = options.indexOf("-p");
+        if (portIndex != -1) {
+            if ((options.size() != 3) || (portIndex + 1 == options.size())) {
+                System.out.println("Invalid ping usage");
                 return;
-            } else if (portNext) {
-                port = option;
-                portNext = false;
-            } else if (option.equals("-p")) {
-                portNext = true;
             } else {
-                host = option;
+                port = options.get(portIndex + 1);
+                options.remove("-p");
+                options.remove(port);
             }
         }
 
-        // FIXME: if no options set, host = "process" !!!
+        String host = options.get(options.size() - 1);
+
         try (Socket socket = new Socket()) {
             System.out.println("Pinging " + host + "...");
             socket.connect(new InetSocketAddress(host, Integer.parseInt(port)), 10000);
             System.out.println("Ping Successful");
         } catch (IOException e) {
-            // Either timeout or unreachable or failed DNS lookup
-            System.out.println("Ping Failed");
+            System.out.println("Ping failed");
+        } catch (NumberFormatException e) {
+            System.out.println("Invalid port value");
         }
     }
 }


### PR DESCRIPTION
Fixed `Ping.java` issue. As I mentioned in `FIXME` comment, ping was connecting to `process` host by default, and the command was failing (when no parameters where passed). Now it's printing help information.
I'm not sure If my implementation is working good, so would be great if someone could check it.

Also `JTerm#parse()` was putting the method name into `optionsArray` if it was empty, but this parameter was not used.