### PR TITLE
Added new features to Files.java, fixed issue

### DIFF
--- a/src/main/java/jterm/JTerm.java
+++ b/src/main/java/jterm/JTerm.java
@@ -38,8 +38,8 @@ public class JTerm {
     // Global directory variable (use "cd" command to change)
     public static String currentDirectory = System.getProperty("user.dir");
 
-    public static boolean IS_WIN = false;
-    public static boolean IS_UNIX = false;
+    public static boolean IS_WIN;
+    public static boolean IS_UNIX;
 
     static {
         Util.setOS();
@@ -59,8 +59,6 @@ public class JTerm {
     public static String command = "";
 
     public static void main(String[] args) {
-        Util.setOS();
-
         System.out.println(
             "JTerm Copyright (C) 2017 Sergix, NCSGeek, chromechris\n"
             + "This program comes with ABSOLUTELY NO WARRANTY.\n"
@@ -80,9 +78,7 @@ public class JTerm {
             return;
         }
 
-        String command = optionsArray.get(0);
-        optionsArray.remove(0);
-
+        String command = optionsArray.remove(0);
         if (!COMMANDS.containsKey(command)) {
             System.out.println("Command \"" + command + "\" is not available");
             return;

--- a/src/main/java/jterm/command/Dir.java
+++ b/src/main/java/jterm/command/Dir.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -101,7 +102,6 @@ public class Dir implements Command {
         }
 
         File[] files = new File(JTerm.currentDirectory).listFiles();
-
         if (files == null) {
             return;
         }
@@ -127,6 +127,7 @@ public class Dir implements Command {
     * directory [...]
     * 	Path to change the working directory to.
     */
+    // FIXME: throws exception if no options specified
     public static void cd(List<String> options) {
         if (options.contains("-h")) {
             System.out.println("Command syntax:\n\tcd [-h] directory\n\nChanges the working directory to the path specified.");
@@ -182,16 +183,24 @@ public class Dir implements Command {
     }
 
     public static void md(List<String> options) {
+        if (options.size() < 1) {
+            throw new CommandException("To few arguments for md");
+        }
         if (options.contains("-h")) {
             System.out.println("Command syntax:\n\tmd [-h] name");
             return;
         }
 
-        StringBuilder nameBuilder = new StringBuilder(Util.getAsString(options));
-        nameBuilder
-                .deleteCharAt(nameBuilder.length() - 1)
-                .insert(0, JTerm.currentDirectory);
-        new File(nameBuilder.toString()).mkdir();
+        String dirName = options.get(0);
+        if (!dirName.startsWith("/")) {
+            dirName = JTerm.currentDirectory + "/" + dirName;
+        }
+
+        try {
+            java.nio.file.Files.createDirectory(Paths.get(dirName));
+        } catch (IOException e) {
+            throw new CommandException("Failed to create directory \'" + dirName + '\'');
+        }
     }
 
     /*

--- a/src/main/java/jterm/command/Dir.java
+++ b/src/main/java/jterm/command/Dir.java
@@ -106,13 +106,7 @@ public class Dir implements Command {
             return;
         }
 
-        FilePrinter printer;
-        if (options.contains("-f")) {
-            printer = FULL_PRINTER;
-        } else {
-            printer = SIMPLE_PRINTER;
-        }
-
+        FilePrinter printer = options.contains("-f") ? FULL_PRINTER : SIMPLE_PRINTER;
 
         System.out.println("[Contents of \"" + JTerm.currentDirectory + "\"]");
         for (File file : files) {

--- a/src/main/java/jterm/command/Files.java
+++ b/src/main/java/jterm/command/Files.java
@@ -19,6 +19,8 @@ package jterm.command;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +28,7 @@ import java.util.function.Consumer;
 
 import jterm.JTerm;
 import jterm.util.Util;
+import sun.management.snmp.jvminstr.JvmThreadInstanceEntryImpl;
 
 public class Files implements Command {
     private static final Map<String, Consumer<List<String>>> FUNCTIONS = new HashMap<>(6);
@@ -37,6 +40,7 @@ public class Files implements Command {
         FUNCTIONS.put("del",      Files::delete);
         FUNCTIONS.put("read",     Files::read);
         FUNCTIONS.put("download", Files::download);
+        FUNCTIONS.put("mv",       Files::move);
     }
 
     @Override
@@ -52,6 +56,31 @@ public class Files implements Command {
             FUNCTIONS.get(command).accept(options);
         } else {
             throw new CommandException("Invalid command name \"" + command + "\"");
+        }
+    }
+
+    public static void move(List<String> options) {
+        if (options.size() < 2) {
+            throw new CommandException("To few arguments for \'mv\'");
+        }
+
+        String sourceName = options.get(0);
+        String destinationName = options.get(1);
+
+        if (!sourceName.startsWith("/")) {
+            sourceName = JTerm.currentDirectory + "/" + sourceName;
+        }
+        if (!destinationName.startsWith("/")) {
+            destinationName = JTerm.currentDirectory + "/" + destinationName;
+        }
+
+        Path source = Paths.get(sourceName);
+        Path destination  = Paths.get(destinationName);
+
+        try {
+            java.nio.file.Files.move(source, destination);
+        } catch (IOException e) {
+            throw new CommandException("Failed to move \'" + sourceName + "\' to \'" + destinationName + '\'', e);
         }
     }
 


### PR DESCRIPTION
Important changes in `jterm.command.Files`:
 * fixed `md()` (issue #73)
 * added `move()` method, that was requested in roadmap
 * updated `delete()` and `read()` methods. I'm using `java.nio.*` instead of `java.io.*`. The code just looks more cleaner
 * added a wrapper class `FilesCommand` that has `minOptionsSize`, `helpInfo` fields and overridden method `accept()` that makes checks for minOptionsSize and prints help info if requested.

Minor changes to `Jterm.java`

This PR is not recommended to be merged (except bugfixes).
I just wanted to say that in my opinion we should somehow generalize the command execution, because it's a bit annoying to read/write code when in each method you have to check the `options` list for `-h` option or if it is empty.

**Before:**
```java
public static void read(List<String> options) {
    if (options.contains("-h") {
        System.out.println("A long help info about read()");
        return;
    }
    if (options.size() < 1) {
        throw new CommandException("To few arguments for read");
    }

    // do read stuff
}
```
**After:**
```java
public static void read(List<String> options) {
    // options are already checked
    // do read stuff
}
```